### PR TITLE
Add trailing slashes to directory links

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,10 +11,10 @@
     <div id="intro">
       <h1>Famo.us and D3 Demos</h1>
     </div>
-    <a href="examples/bar-chart">Bars Charts</a>
-    <a href="examples/bubble-hierarchy">Bubble Hierarchy</a>
-    <a href="examples/crunchbase-bubbles">Bubble Charts</a>
-    <a href="examples/crunchbase-treemap">Treemap Charts</a>
-    <a href="examples/bubble-clusters">Bubble Clusters</a>
+    <a href="examples/bar-chart/">Bars Charts</a>
+    <a href="examples/bubble-hierarchy/">Bubble Hierarchy</a>
+    <a href="examples/crunchbase-bubbles/">Bubble Charts</a>
+    <a href="examples/crunchbase-treemap/">Treemap Charts</a>
+    <a href="examples/bubble-clusters/">Bubble Clusters</a>
   </body>
 </html>


### PR DESCRIPTION
I served this up using the node package "http-server" -- when I clicked the links the examples failed to load due to path issues, and the trailing slashes fixed the issue.  I expect this should work for all servers.
